### PR TITLE
Patch site-wide settings

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: "AB-3"
+title: "GradPad"
 theme: jekyll-theme-hacker
 
 header_pages:
@@ -8,7 +8,7 @@ header_pages:
 
 markdown: kramdown
 
-repository: "se-edu/addressbook-level3"
+repository: "AY2021S1-CS2103T-T09-1/tp"
 github_icon: "images/github-icon.png"
 
 plugins:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,17 @@
 ---
 layout: page
-title: AddressBook Level-3
+title: GradPad
 ---
 
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
-[![codecov](https://codecov.io/gh/se-edu/addressbook-level3/branch/master/graph/badge.svg)](https://codecov.io/gh/se-edu/addressbook-level3)
+[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/AY2021S1-CS2103T-T09-1/tp/actions)
+[![codecov](https://codecov.io/gh/se-edu/addressbook-level3/branch/master/graph/badge.svg)](https://codecov.io/gh/AY2021S1-CS2103T-T09-1/tp)
 
 ![Ui](images/Ui.png)
 
-**AddressBook is a desktop application for managing your contact details.** While it has a GUI, most of the user interactions happen using a CLI (Command Line Interface).
+**GradPad is a desktop application for managing your NUS modules.** While it has a GUI, most of the user interactions happen using a CLI (Command Line Interface).
 
-* If you are interested in using AddressBook, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#quick-start).
-* If you are interested about developing AddressBook, the [**Developer Guide**](DeveloperGuide.html) is a good place to start.
+* If you are interested in using GradPad, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#quick-start).
+* If you are interested about developing GradPad, the [**Developer Guide**](DeveloperGuide.html) is a good place to start.
 
 
 **Acknowledgements**


### PR DESCRIPTION
The level for website-adapted wasn't passing:
![Screenshot 2020-09-27 at 12 19 25 PM](https://user-images.githubusercontent.com/31149701/94355975-af9b3180-00bb-11eb-8402-1a4b231f3f3e.png)

Turns out we had to update the Jekyll config for our Github Page too.

Changes in this PR:

- Update `_config.yml`'s `title` and `repo` global variables

- Update `index.md` (the landing page for our website) cos I think we missed it out

Resolves #29 
