### PR TITLE
Bugfix: make NusmodsDataManager constructor public

### DIFF
--- a/src/main/java/seedu/address/nusmods/NusmodsDataManager.java
+++ b/src/main/java/seedu/address/nusmods/NusmodsDataManager.java
@@ -19,7 +19,10 @@ public class NusmodsDataManager implements NusmodsData {
     private final String filePath;
     private final DataFetcher dataFetcher;
 
-    NusmodsDataManager() {
+    /**
+     * Default public constructor to create an NusmodsDataManager object.
+     */
+    public NusmodsDataManager() {
         dataFetcher = new DataFetcherManager();
         filePath = DataFetcher.DATA_FILE_PATH;
     }


### PR DESCRIPTION
Other packages couldn't instantiate `NusmodsDataManager` objects because its constructor wasn't public. Now it is.