### PR TITLE
Add Tags command and support finding by tags

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,31 +2,33 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.Predicate;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.module.ModuleCodeContainsKeywordsPredicate;
+import seedu.address.model.module.Module;
 
 /**
- * Finds and lists all modules in GradPad whose name contains any of the argument keywords.
+ * Finds and lists all modules in GradPad whose name or tag contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all modules whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all modules whose names or tags contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " CS2103T CS1101s CS2030";
 
-    private final ModuleCodeContainsKeywordsPredicate predicate;
+    private final Predicate<Module> predicate;
 
     /**
      * Creates a FindCommand to filter module(s) based on the specified predicate.
      *
      * @param predicate the predicate used to filter relevant module(s).
      */
-    public FindCommand(ModuleCodeContainsKeywordsPredicate predicate) {
+    public FindCommand(Predicate<Module> predicate) {
         assert(predicate != null);
         this.predicate = predicate;
     }

--- a/src/main/java/seedu/address/logic/commands/TagsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagsCommand.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.model.Model;
+
+/**
+ * Lists all tags in GradPad.
+ */
+public class TagsCommand extends Command {
+
+    public static final String COMMAND_WORD = "tags";
+
+    public static final String MESSAGE_SUCCESS = "Listed all tags:\n";
+    public static final String MESSAGE_NO_TAGS = "There are no tags.";
+
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        List<String> tagNames = model.getGradPad().getTags().getTagNames();
+        if (tagNames.isEmpty()) {
+            return new CommandResult(MESSAGE_NO_TAGS);
+        }
+
+        String tags = String.join("\n", tagNames);
+        return new CommandResult(MESSAGE_SUCCESS + tags);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -8,6 +8,7 @@ import java.util.function.Predicate;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.CompoundFindPredicate;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCodeContainsKeywordsPredicate;
 import seedu.address.model.module.ModuleContainsTagsPredicate;
@@ -34,26 +35,4 @@ public class FindCommandParser implements Parser<FindCommand> {
         return new FindCommand(new CompoundFindPredicate(keywords));
     }
 
-    public static class CompoundFindPredicate implements Predicate<Module> {
-        private final List<String> keywords;
-
-        CompoundFindPredicate(List<String> keywords) {
-            this.keywords = keywords;
-        }
-
-        @Override
-        public boolean test(Module module) {
-            Predicate<Module> moduleCodePredicate = new ModuleCodeContainsKeywordsPredicate(keywords);
-            Predicate<Module> tagsPredicate = new ModuleContainsTagsPredicate(keywords);
-            // chain the predicates
-            return moduleCodePredicate.or(tagsPredicate).test(module);
-        }
-
-        @Override
-        public boolean equals(Object other) {
-            return other == this // short circuit if same object
-                           || (other instanceof CompoundFindPredicate // instanceof handles nulls
-                                       && keywords.equals(((CompoundFindPredicate) other).keywords)); // state check
-        }
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -30,10 +30,30 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         List<String> keywords = Arrays.asList(trimmedArgs.split("\\s+"));
-        Predicate<Module> moduleCodePredicate = new ModuleCodeContainsKeywordsPredicate(keywords);
-        Predicate<Module> tagsPredicate = new ModuleContainsTagsPredicate(keywords);
 
-        return new FindCommand(moduleCodePredicate.or(tagsPredicate));
+        return new FindCommand(new CompoundFindPredicate(keywords));
     }
 
+    public static class CompoundFindPredicate implements Predicate<Module> {
+        private final List<String> keywords;
+
+        CompoundFindPredicate(List<String> keywords) {
+            this.keywords = keywords;
+        }
+
+        @Override
+        public boolean test(Module module) {
+            Predicate<Module> moduleCodePredicate = new ModuleCodeContainsKeywordsPredicate(keywords);
+            Predicate<Module> tagsPredicate = new ModuleContainsTagsPredicate(keywords);
+            // chain the predicates
+            return moduleCodePredicate.or(tagsPredicate).test(module);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other == this // short circuit if same object
+                           || (other instanceof CompoundFindPredicate // instanceof handles nulls
+                                       && keywords.equals(((CompoundFindPredicate) other).keywords)); // state check
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -4,14 +4,10 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Predicate;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.CompoundFindPredicate;
-import seedu.address.model.module.Module;
-import seedu.address.model.module.ModuleCodeContainsKeywordsPredicate;
-import seedu.address.model.module.ModuleContainsTagsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -3,10 +3,14 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCodeContainsKeywordsPredicate;
+import seedu.address.model.module.ModuleContainsTagsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -25,9 +29,11 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        List<String> keywords = Arrays.asList(trimmedArgs.split("\\s+"));
+        Predicate<Module> moduleCodePredicate = new ModuleCodeContainsKeywordsPredicate(keywords);
+        Predicate<Module> tagsPredicate = new ModuleContainsTagsPredicate(keywords);
 
-        return new FindCommand(new ModuleCodeContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return new FindCommand(moduleCodePredicate.or(tagsPredicate));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/GradPadParser.java
+++ b/src/main/java/seedu/address/logic/parser/GradPadParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RequiredCommand;
 import seedu.address.logic.commands.ScienceCommand;
 import seedu.address.logic.commands.SearchCommand;
+import seedu.address.logic.commands.TagsCommand;
 import seedu.address.logic.commands.YesCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -87,6 +88,9 @@ public class GradPadParser {
 
         case YesCommand.COMMAND_WORD:
             return new YesCommand();
+
+        case TagsCommand.COMMAND_WORD:
+            return new TagsCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/model/GradPad.java
+++ b/src/main/java/seedu/address/model/GradPad.java
@@ -90,7 +90,7 @@ public class GradPad implements ReadOnlyGradPad {
 
         // Reuse existing tags if possible
         Set<Tag> replacedTags = tags.checkAndReplaceTags(m.getTags());
-        Module toAdd = new Module(m.getModuleCode(), m.getModularCredits(), replacedTags);
+        Module toAdd = new Module(m.getModuleCode(), m.getModuleTitle(), m.getModularCredits(), replacedTags);
 
         modules.add(toAdd);
     }
@@ -107,8 +107,9 @@ public class GradPad implements ReadOnlyGradPad {
         tags.remove(target.getTags());
         // Get new tags and reuse existing tags if possible
         Set<Tag> replacedTags = tags.checkAndReplaceTags(editedModule.getTags());
-        Module editedModuleToAdd = new Module(editedModule.getModuleCode(), editedModule.getModularCredits(),
-                                           replacedTags);
+        Module editedModuleToAdd =
+                new Module(editedModule.getModuleCode(), editedModule.getModuleTitle(),
+                           editedModule.getModularCredits(), replacedTags);
 
         modules.setModule(target, editedModuleToAdd);
     }

--- a/src/main/java/seedu/address/model/ReadOnlyGradPad.java
+++ b/src/main/java/seedu/address/model/ReadOnlyGradPad.java
@@ -1,7 +1,9 @@
 package seedu.address.model;
 
+
 import javafx.collections.ObservableList;
 import seedu.address.model.module.Module;
+import seedu.address.model.tag.UniqueTagMap;
 
 /**
  * Unmodifiable view of a GradPad
@@ -14,4 +16,8 @@ public interface ReadOnlyGradPad {
      */
     ObservableList<Module> getModuleList();
 
+    /**
+     * Returns the unique tags in the GradPad.
+     */
+    UniqueTagMap getTags();
 }

--- a/src/main/java/seedu/address/model/ReadOnlyGradPad.java
+++ b/src/main/java/seedu/address/model/ReadOnlyGradPad.java
@@ -1,6 +1,5 @@
 package seedu.address.model;
 
-
 import javafx.collections.ObservableList;
 import seedu.address.model.module.Module;
 import seedu.address.model.tag.UniqueTagMap;

--- a/src/main/java/seedu/address/model/module/CompoundFindPredicate.java
+++ b/src/main/java/seedu/address/model/module/CompoundFindPredicate.java
@@ -1,0 +1,27 @@
+package seedu.address.model.module;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class CompoundFindPredicate implements Predicate<Module> {
+    private final List<String> keywords;
+
+    public CompoundFindPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Module module) {
+        Predicate<Module> moduleCodePredicate = new ModuleCodeContainsKeywordsPredicate(keywords);
+        Predicate<Module> tagsPredicate = new ModuleContainsTagsPredicate(keywords);
+        // chain the predicates
+        return moduleCodePredicate.or(tagsPredicate).test(module);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                       || (other instanceof CompoundFindPredicate // instanceof handles nulls
+                                   && keywords.equals(((CompoundFindPredicate) other).keywords)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/module/ModuleContainsTagsPredicate.java
+++ b/src/main/java/seedu/address/model/module/ModuleContainsTagsPredicate.java
@@ -1,0 +1,28 @@
+package seedu.address.model.module;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Module} contains a {@code Tag} matching any of the tag names given.
+ */
+public class ModuleContainsTagsPredicate implements Predicate<Module> {
+    private final List<String> tagNames;
+
+    /**
+     * Creates a new ModuleContainsTagsPredicate to test whether a module contains any tag that
+     * matches any of the tag names in the specified list.
+     *
+     * @param tagNames list of tag names.
+     */
+    public ModuleContainsTagsPredicate(List<String> tagNames) {
+        this.tagNames = tagNames;
+    }
+
+    @Override
+    public boolean test(Module module) {
+        return tagNames.stream().anyMatch(name ->
+              module.getTags().stream().anyMatch(tag ->
+                     tag.tagName.equals(name)));
+    }
+}

--- a/src/main/java/seedu/address/model/module/ModuleContainsTagsPredicate.java
+++ b/src/main/java/seedu/address/model/module/ModuleContainsTagsPredicate.java
@@ -23,6 +23,6 @@ public class ModuleContainsTagsPredicate implements Predicate<Module> {
     public boolean test(Module module) {
         return tagNames.stream().anyMatch(name ->
               module.getTags().stream().anyMatch(tag ->
-                     tag.tagName.equals(name)));
+                     tag.tagName.equalsIgnoreCase(name)));
     }
 }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -13,9 +13,11 @@ public class Tag {
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String tagName;
+    private int moduleCount;
 
     /**
-     * Constructs a {@code Tag}.
+     * Constructs a {@code Tag}. By default, a tag has a module count of 1 since is it constructed by a
+     * module that contains it.
      *
      * @param tagName A valid tag name.
      */
@@ -23,6 +25,7 @@ public class Tag {
         requireNonNull(tagName);
         checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
         this.tagName = tagName;
+        moduleCount = 1;
     }
 
     /**
@@ -30,6 +33,42 @@ public class Tag {
      */
     public static boolean isValidTagName(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns the no. of modules that contain this tag.
+     *
+     * @return the module count
+     */
+    public int getModuleCount() {
+        return moduleCount;
+    }
+
+    /**
+     * Increments the no. of modules that contain this tag. This is used when:
+     * 1. A new module with this tag is created
+     * 2. An existing module is edited to contain this tag
+     */
+    public void incrementModuleCount() {
+        moduleCount++;
+    }
+
+    /**
+     * Decrements the no. of modules that contain this tag. This is used when:
+     * 1. A module with this tag is deleted
+     * 2. An existing module is edited and no longer contains this tag
+     */
+    public void decrementModuleCount() {
+        moduleCount--;
+    }
+
+    /**
+     * Checks if this tag is being used by any {@code Module} in GradPad.
+     *
+     * @return True if the tag is no longer used by any {@code Module}, false if otherwise.
+     */
+    public boolean isEmpty() {
+        return moduleCount == 0;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/tag/UniqueTagMap.java
+++ b/src/main/java/seedu/address/model/tag/UniqueTagMap.java
@@ -1,0 +1,85 @@
+package seedu.address.model.tag;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Encapsulates data and logic to maintain a set of unique {@code Tag} objects in GradPad.
+ * With this, duplicate tags are not created in GradPad unnecessarily, thus encouraging reuse of {@code Tag} objects
+ * across {@code Module} objects.
+ */
+public class UniqueTagMap {
+    /**
+     * A map of tag names to actual {@code Tag} objects
+     */
+    private final Map<String, Tag> tagMap = new HashMap<>();
+
+    /**
+     * Replaces the current map of {@code Tag} objects with the contents of a new {@code UniqueTagMap}.
+     *
+     * @param replacement The replacement {@code UniqueTagMap} to copy from.
+     */
+    public void setTags(UniqueTagMap replacement) {
+        tagMap.clear();
+        tagMap.putAll(replacement.tagMap);
+    }
+
+    /**
+     * Given a set of {@code Tags}, decreases the module count of each tag, and if the tag ends up as not being
+     * used by any {@code Module}, removes it from {@code UniqueTagMap}. This is used to effect "untagging"
+     * operations, where a module no longer uses these tags, or if a module is deleted.
+     *
+     * @param tags The set of tags to "untag".
+     */
+    public void remove(Set<Tag> tags) {
+        for (Tag tag : tags) {
+            tag.decrementModuleCount();
+            if (tag.isEmpty()) {
+                tagMap.remove(tag.tagName);
+            }
+        }
+    }
+
+    /**
+     * Given a set of {@code Tags}, checks if each tag already exists in {@code UniqueTagMap}.
+     * If it does, then it replaces that tag with the existing tag so that there is no need to create a new tag.
+     * Else, it adds that new tag to GradPad.
+     *
+     * @param tagsToCheck The set of tags to check through.
+     * @return The new set of tags which has any duplicate new tags replaced with their existing equivalent.
+     */
+    public Set<Tag> checkAndReplaceTags(Set<Tag> tagsToCheck) {
+        Set<Tag> replacedTagSet = new HashSet<>();
+
+        for (Tag tag : tagsToCheck) {
+            if (tagMap.containsKey(tag.tagName)) {
+                Tag existingTag = tagMap.get(tag.tagName);
+                existingTag.incrementModuleCount();
+                replacedTagSet.add(existingTag);
+            } else {
+                tagMap.put(tag.tagName, tag);
+                replacedTagSet.add(tag);
+            }
+        }
+
+        return replacedTagSet;
+    }
+
+    /**
+     * Returns a list of tag names of all tags in {@code UniqueTagMap}
+     *
+     * @return a list of tag names
+     */
+    public List<String> getTagNames() {
+        return new ArrayList<>(tagMap.keySet());
+    }
+
+    @Override
+    public String toString() {
+        return tagMap.toString();
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_MODULES_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_CORE;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalModules.CS2103T;
 import static seedu.address.testutil.TypicalModules.CS3216;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.module.CompoundFindPredicate;
 import seedu.address.model.module.ModuleCodeContainsKeywordsPredicate;
 
 /**
@@ -56,7 +58,7 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noModuleFound() {
         String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 0);
-        ModuleCodeContainsKeywordsPredicate predicate = preparePredicate(" ");
+        CompoundFindPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredModuleList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -64,9 +66,29 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_multipleKeywords_multipleModulesFound() {
+    public void execute_multipleModuleCodes_multipleModulesFound() {
         String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 2);
-        ModuleCodeContainsKeywordsPredicate predicate = preparePredicate("CS2103T CS3216");
+        CompoundFindPredicate predicate = preparePredicate("CS2103T CS3216");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredModuleList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CS2103T, CS3216), model.getFilteredModuleList());
+    }
+
+    @Test
+    public void execute_oneTagKeyword_oneModuleFound() {
+        String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 1);
+        CompoundFindPredicate predicate = preparePredicate(VALID_TAG_CORE);
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredModuleList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.singletonList(CS2103T), model.getFilteredModuleList());
+    }
+
+    @Test
+    public void execute_tagAndModuleCodeKeywords_multipleModulesFound() {
+        String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 2);
+        CompoundFindPredicate predicate = preparePredicate(VALID_TAG_CORE + " CS3216");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredModuleList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -76,7 +98,7 @@ public class FindCommandTest {
     /**
      * Parses {@code userInput} into a {@code ModuleCodeContainsKeywordsPredicate}.
      */
-    private ModuleCodeContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new ModuleCodeContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private CompoundFindPredicate preparePredicate(String userInput) {
+        return new CompoundFindPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -86,6 +86,16 @@ public class FindCommandTest {
     }
 
     @Test
+    public void execute_oneCapitalizedTagKeyword_oneModuleFound() {
+        String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 1);
+        CompoundFindPredicate predicate = preparePredicate(VALID_TAG_CORE.toUpperCase());
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredModuleList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.singletonList(CS2103T), model.getFilteredModuleList());
+    }
+
+    @Test
     public void execute_tagAndModuleCodeKeywords_multipleModulesFound() {
         String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 2);
         CompoundFindPredicate predicate = preparePredicate(VALID_TAG_CORE + " CS3216");

--- a/src/test/java/seedu/address/logic/commands/TagsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagsCommandTest.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.testutil.TypicalModules.getTypicalGradPad;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class TagsCommandTest {
+
+    private Model modelWithTags;
+    private Model modelWithoutTags;
+
+    @BeforeEach
+    public void setUp() {
+        modelWithTags = new ModelManager(getTypicalGradPad(), new UserPrefs());
+        modelWithoutTags = new ModelManager();
+    }
+
+    @Test
+    public void execute_modelWithTags_printsTags() {
+        List<String> tagNames = modelWithTags.getGradPad().getTags().getTagNames();
+        String expectedMessage = TagsCommand.MESSAGE_SUCCESS + String.join("\n", tagNames);
+        TagsCommand tagsCommand = new TagsCommand();
+
+        // actual and expected model are the same as there should be no change
+        CommandTestUtil.assertCommandSuccess(tagsCommand, modelWithTags, expectedMessage, modelWithTags);
+    }
+
+    @Test
+    public void execute_modelWithoutTags_noTagsMessage() {
+        String expectedMessage = TagsCommand.MESSAGE_NO_TAGS;
+        TagsCommand tagsCommand = new TagsCommand();
+
+        // actual and expected model are the same as there should be no change
+        CommandTestUtil.assertCommandSuccess(tagsCommand, modelWithoutTags, expectedMessage, modelWithoutTags);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -5,11 +5,14 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.module.ModuleCodeContainsKeywordsPredicate;
+import seedu.address.model.module.CompoundFindPredicate;
+import seedu.address.model.module.Module;
 
 public class FindCommandParserTest {
 
@@ -23,8 +26,10 @@ public class FindCommandParserTest {
     @Test
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
-        FindCommand expectedFindCommand =
-                new FindCommand(new ModuleCodeContainsKeywordsPredicate(Arrays.asList("CS2103T", "CS3216")));
+        List<String> keywords = Arrays.asList("CS2103T", "CS3216");
+        Predicate<Module> expectedPredicate = new CompoundFindPredicate(keywords);
+
+        FindCommand expectedFindCommand = new FindCommand(expectedPredicate);
         assertParseSuccess(parser, "CS2103T CS3216", expectedFindCommand);
 
         // multiple whitespaces between keywords

--- a/src/test/java/seedu/address/logic/parser/GradPadParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/GradPadParserTest.java
@@ -23,9 +23,10 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.TagsCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.CompoundFindPredicate;
 import seedu.address.model.module.Module;
-import seedu.address.model.module.ModuleCodeContainsKeywordsPredicate;
 import seedu.address.testutil.EditModuleDescriptorBuilder;
 import seedu.address.testutil.ModuleBuilder;
 import seedu.address.testutil.ModuleUtil;
@@ -74,7 +75,7 @@ public class GradPadParserTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new ModuleCodeContainsKeywordsPredicate(keywords)), command);
+        assertEquals(new FindCommand(new CompoundFindPredicate(keywords)), command);
     }
 
     @Test
@@ -93,6 +94,12 @@ public class GradPadParserTest {
     public void parseCommand_checkMc() throws Exception {
         assertTrue(parser.parseCommand(CheckMcCommand.COMMAND_WORD) instanceof CheckMcCommand);
         assertTrue(parser.parseCommand(CheckMcCommand.COMMAND_WORD + " 3") instanceof CheckMcCommand);
+    }
+
+    @Test
+    public void parseCommand_tags() throws Exception {
+        assertTrue(parser.parseCommand(TagsCommand.COMMAND_WORD) instanceof TagsCommand);
+        assertTrue(parser.parseCommand(TagsCommand.COMMAND_WORD + " 3") instanceof TagsCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/GradPadTest.java
+++ b/src/test/java/seedu/address/model/GradPadTest.java
@@ -22,6 +22,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.exceptions.DuplicateModuleException;
+import seedu.address.model.tag.UniqueTagMap;
 import seedu.address.testutil.ModuleBuilder;
 
 public class GradPadTest {
@@ -90,6 +91,7 @@ public class GradPadTest {
      */
     private static class GradPadStub implements ReadOnlyGradPad {
         private final ObservableList<Module> modules = FXCollections.observableArrayList();
+        private final UniqueTagMap tags = new UniqueTagMap();
 
         GradPadStub(Collection<Module> modules) {
             this.modules.setAll(modules);
@@ -98,6 +100,11 @@ public class GradPadTest {
         @Override
         public ObservableList<Module> getModuleList() {
             return modules;
+        }
+
+        @Override
+        public UniqueTagMap getTags() {
+            return tags;
         }
     }
 

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -1,5 +1,9 @@
 package seedu.address.model.tag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -18,9 +22,72 @@ public class TagTest {
     }
 
     @Test
-    public void isValidTagName() {
+    public void isValidTagName_null_throwsNullPointerException() {
         // null tag name
         assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+    }
+
+    @Test
+    public void constructor_validTagName_tagWithDefaultModuleCount() {
+        String expectedTagName = "core";
+        int expectedModuleCount = 1;
+        Tag actualTag = new Tag(expectedTagName);
+        assertEquals(expectedTagName, actualTag.tagName);
+        assertEquals(expectedModuleCount, actualTag.getModuleCount());
+    }
+
+    @Test
+    public void moduleCount() {
+        Tag tag = new Tag("core");
+
+        // module count: 1 --> 0
+        tag.decrementModuleCount();
+        assertEquals(0, tag.getModuleCount());
+        assertTrue(tag.isEmpty());
+
+        // module count: 0 --> 1
+        tag.incrementModuleCount();
+        assertEquals(1, tag.getModuleCount());
+    }
+
+    @Test
+    public void equals() {
+        Tag tag1 = new Tag("core");
+
+        // null --> false
+        assertFalse(tag1.equals(null));
+        // different types --> false
+        assertFalse(tag1.equals("core"));
+
+
+        // same object --> true
+        assertTrue(tag1.equals(tag1));
+
+        // different object, same tagName --> true
+        assertTrue(tag1.equals(new Tag("core")));
+
+        // different object, same tagName, different moduleCount --> true
+        Tag tag2 = new Tag("core");
+        tag2.incrementModuleCount();
+        assertTrue(tag1.equals(tag2));
+
+        // different object, different tagName --> false
+        assertFalse(tag1.equals(new Tag("notCore")));
+    }
+
+    @Test
+    public void hashCodeTest() {
+        Tag tag1 = new Tag("core");
+        Tag tag2 = new Tag("notCore");
+
+        // same object --> same hashcode
+        assertEquals(tag1.hashCode(), tag1.hashCode());
+
+        // different object, same tagName --> same hashcode
+        assertEquals(tag1.hashCode(), new Tag("core").hashCode());
+
+        //different object, different tagName --> different hashcode
+        assertNotEquals(tag1.hashCode(), tag2.hashCode());
     }
 
 }

--- a/src/test/java/seedu/address/model/tag/UniqueTagMapTest.java
+++ b/src/test/java/seedu/address/model/tag/UniqueTagMapTest.java
@@ -1,0 +1,116 @@
+package seedu.address.model.tag;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+public class UniqueTagMapTest {
+    @Test
+    public void checkAndReplaceTags_emptySet_noChange() {
+        UniqueTagMap map = new UniqueTagMap();
+        map.checkAndReplaceTags(new HashSet<>());
+        assertTrue(map.getTagNames().isEmpty());
+    }
+
+    @Test
+    public void checkAndReplaceTags_newDistinctTag_populatesMap() {
+        UniqueTagMap map = new UniqueTagMap();
+        Set<Tag> tagSet = new HashSet<>();
+        tagSet.add(new Tag("core"));
+        map.checkAndReplaceTags(tagSet);
+
+        List<String> actualNames = map.getTagNames();
+        List<String> expectedNames = Collections.singletonList("core");
+        assertEquals(expectedNames, actualNames);
+    }
+
+    @Test
+    public void checkAndReplaceTags_existingTag_notAdded() {
+        UniqueTagMap map = new UniqueTagMap();
+        Set<Tag> tagSet = new HashSet<>();
+        tagSet.add(new Tag("core"));
+        map.checkAndReplaceTags(tagSet);
+
+        // Add a tag with duplicate tagName
+        Set<Tag> duplicateTagSet = new HashSet<>();
+        duplicateTagSet.add(new Tag("core"));
+        map.checkAndReplaceTags(duplicateTagSet);
+
+        List<String> actualNames = map.getTagNames();
+        // there should only be one name, i.e. duplicates aren't added
+        List<String> expectedNames = Collections.singletonList("core");
+        assertEquals(expectedNames, actualNames);
+    }
+
+    @Test
+    public void remove_emptySet_noChange() {
+        // set up and populate
+        UniqueTagMap map = new UniqueTagMap();
+        Set<Tag> tagSet = new HashSet<>();
+        tagSet.add(new Tag("core"));
+        map.checkAndReplaceTags(tagSet);
+
+        // empty set
+        map.remove(new HashSet<>());
+
+        List<String> actualNames = map.getTagNames();
+        List<String> expectedNames = Collections.singletonList("core");
+        assertEquals(expectedNames, actualNames);
+    }
+
+    @Test
+    public void remove_tagWithMoreThanOneModule_moduleCountDecreased() {
+        // set up and populate
+        UniqueTagMap map = new UniqueTagMap();
+        Set<Tag> tagSet = new HashSet<>();
+        Tag tag = new Tag("core");
+        tag.incrementModuleCount();
+        tagSet.add(tag);
+        map.checkAndReplaceTags(tagSet);
+        map.remove(tagSet);
+
+        // tag should still remain in map
+        List<String> actualNames = map.getTagNames();
+        List<String> expectedNames = Collections.singletonList("core");
+        assertEquals(expectedNames, actualNames);
+
+        // tag's moduleCount should be decremented
+        assertEquals(1, tag.getModuleCount());
+    }
+
+    @Test
+    public void remove_tagWithOnlyOneModule_tagRemoved() {
+        // set up and populate
+        UniqueTagMap map = new UniqueTagMap();
+        Set<Tag> tagSet = new HashSet<>();
+        tagSet.add(new Tag("core"));
+        map.checkAndReplaceTags(tagSet);
+        map.remove(tagSet);
+
+        // tag should be removed from map
+        assertTrue(map.getTagNames().isEmpty());
+    }
+
+    @Test
+    public void setTags_nonEmptyUniqueTagMap_tagsReplaced() {
+        // set up and populate
+        UniqueTagMap map = new UniqueTagMap();
+        Set<Tag> tagSet = new HashSet<>();
+        tagSet.add(new Tag("core"));
+        map.checkAndReplaceTags(tagSet);
+
+        UniqueTagMap replacement = new UniqueTagMap();
+        Set<Tag> replacementSet = new HashSet<>();
+        replacementSet.add(new Tag("nonCore"));
+        replacement.checkAndReplaceTags(replacementSet);
+
+        map.setTags(replacement);
+        assertEquals(replacement.getTagNames(), map.getTagNames());
+    }
+}


### PR DESCRIPTION
#### Feature: Let users list out all tags (closes #124)
- Add `TagsCommand`
- Refactor GradPad to use a `UniqueTagMap` to keep track of tags. This allows us to get a list of unique tags without having to loop through every module and checking. This is also what was suggested in the AB3 DG:

![Screenshot 2020-10-27 at 3 48 39 PM](https://user-images.githubusercontent.com/31149701/97271732-e6579980-186b-11eb-9396-530057f4317b.png)

- Add a moduleCount field to `Tag`, which keeps track of how many modules contain it. See below for why.
- When a module is added:
  1. See if any of the tags to be added already exist in `UniqueTagMap` and use the existing ones instead.
  2. Else, add all tags that are actually new to `UniqueTagMap`.
- When a module is deleted:
  1. Decrease the moduleCount of all tags in that module.
  2. Only delete a tag from `UniqueTagMap` if its moduleCount is 0

#### Feature: Let `find` command search by tags (closes #123)
- Add `ModuleContainsTagsPredicate`
- Add `CompoundFindPredicate`, which basically combines `ModuleCodeContainsKeywordsPredicate` and `ModuleContainsTagsPredicate`
- Tweak `FindCommandParser` to parse and create a `CompoundFindPredicate` instead
- Tweak `FindCommand` to accept `Predicate<Module>` (actually idk why this wasn't there in the first place to support OCP)

#### Tests:
- Add tests for all new classes written
- Tweak/add tests for existing classes that were tweaked

