### PR TITLE
Case insensitive tags within each module

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -96,8 +96,12 @@ public class ParserUtil {
     public static Set<Tag> parseTags(Collection<String> tags) throws ParseException {
         requireNonNull(tags);
         final Set<Tag> tagSet = new HashSet<>();
+        final Set<String> tagNameSet = new HashSet<>();
         for (String tagName : tags) {
-            tagSet.add(parseTag(tagName));
+            if (!tagNameSet.contains(tagName.toLowerCase())) {
+                tagSet.add(parseTag(tagName));
+                tagNameSet.add(tagName.toLowerCase());
+            }
         }
         return tagSet;
     }

--- a/src/main/java/seedu/address/model/GradPad.java
+++ b/src/main/java/seedu/address/model/GradPad.java
@@ -95,9 +95,7 @@ public class GradPad implements ReadOnlyGradPad {
         assert m != null;
 
         // Reuse existing tags if possible
-        Set<Tag> replacedTags = tags.checkAndReplaceTags(m.getTags());
-        Module toAdd = new Module(m.getModuleCode(), m.getModuleTitle(), m.getModularCredits(), replacedTags);
-
+        Module toAdd = getModuleWithReplacedTags(m);
         modules.add(toAdd);
     }
 
@@ -112,11 +110,7 @@ public class GradPad implements ReadOnlyGradPad {
         // "untag" all tags in the module we're going to edit
         tags.remove(target.getTags());
         // Get new tags and reuse existing tags if possible
-        Set<Tag> replacedTags = tags.checkAndReplaceTags(editedModule.getTags());
-        Module editedModuleToAdd =
-                new Module(editedModule.getModuleCode(), editedModule.getModuleTitle(),
-                           editedModule.getModularCredits(), replacedTags);
-
+        Module editedModuleToAdd = getModuleWithReplacedTags(editedModule);
         modules.setModule(target, editedModuleToAdd);
     }
 
@@ -131,6 +125,11 @@ public class GradPad implements ReadOnlyGradPad {
     }
 
     //// util methods
+    private Module getModuleWithReplacedTags(Module m) {
+        Set<Tag> replacedTags = tags.checkAndReplaceTags(m.getTags());
+        return new Module(m.getModuleCode(), m.getModuleTitle(),
+                          m.getModularCredits(), replacedTags);
+    }
 
     @Override
     public String toString() {

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -27,6 +27,8 @@ public class ParserUtilTest {
     private static final String VALID_CREDITS = "4";
     private static final String VALID_TAG_1 = "core";
     private static final String VALID_TAG_2 = "nonCore";
+    private static final String VALID_LOWERCASE_TAG = "foundation";
+    private static final String VALID_UPPERCASE_TAG = "FOUNDATION";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -133,6 +135,14 @@ public class ParserUtilTest {
     public void parseTags_collectionWithValidTags_returnsTagSet() throws Exception {
         Set<Tag> actualTagSet = ParserUtil.parseTags(Arrays.asList(VALID_TAG_1, VALID_TAG_2));
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
+
+        assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseTags_collectionWithDuplicateLettercaseTags_tagSetOnlyIncludesFirst() throws Exception {
+        Set<Tag> actualTagSet = ParserUtil.parseTags(Arrays.asList(VALID_LOWERCASE_TAG, VALID_UPPERCASE_TAG));
+        Set<Tag> expectedTagSet = new HashSet<>(Collections.singletonList(new Tag(VALID_LOWERCASE_TAG)));
 
         assertEquals(expectedTagSet, actualTagSet);
     }


### PR DESCRIPTION
Closes #148 

As reported, we currently allow case-sensitive tags to be added to a single module, i.e. "foundation", "Foundation", which is confusing since the `find` command is case-insensitive.

Changes
* Tweak `ParserUtil.parseTags` to only add the first occurrence of a tag amongst duplicates. E.g. "core", "Core", "cOre" will only result in "core" being added. Also added a test for this.
* Minor refactoring to `GradPad` class's `addModule` and `setModule` methods. They duplicate the same code to replace tags so I've extracted that out into a `getModuleWithReplacedTags` fxn.