### PR TITLE
Enhancement/multiword tags

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -139,7 +139,8 @@ automatically retrieves them for you using data from NUSMods.
 <div markdown="block" class="alert alert-info">
 
 **:information_source: Note:**<br>
-You cannot add a module that has been previously added as GradPad does not allow duplicate modules.
+* You cannot add a module that has been previously added as GradPad does not allow duplicate modules.
+* You can use multiple words in a tag. However, there should only be a single space between any 2 words.
 
 </div>
 
@@ -224,8 +225,8 @@ have added. You want to check and see all CS-coded modules with the "core" tag.
 
 The `find` command allows you to filter the Completed Modules list to display the modules that you want to see. 
 You can do this by specifying parts of the module code of the module(s) you wish to display.
-Additionally, you can also specify the tags of the module(s) you wish to display. When specifying tags however,
-you must type out the entire tag and not just a part of it.
+Additionally, you can also specify the tags of the module(s) you wish to display. Likewise, you can also simply
+specify parts of a tag instead of the entire tag.
 
 Instead of scrolling through the long Completed Modules list and checking the modules one by one, you can easily filter the list to display that module by `find`-ing said module.
 

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -13,8 +13,7 @@ public class Messages {
         + "more characters as a suffix. It is also case-insensitive.";
     public static final String MESSAGE_CONSTRAINTS_TITLE = "Module titles should only contain alphanumeric "
         + "characters and spaces.";
-    public static final String MESSAGE_CONSTRAINTS_TAG = "Tag descriptions should be alphanumeric and "
-        + "should not contain spaces.";
+    public static final String MESSAGE_CONSTRAINTS_TAG = "Tag descriptions should be alphanumeric and non-empty.";
 
     // general
     public static final String MESSAGE_NEED_HELP = "If you need help, type \"help\".";

--- a/src/main/java/seedu/address/model/module/ModuleContainsTagsPredicate.java
+++ b/src/main/java/seedu/address/model/module/ModuleContainsTagsPredicate.java
@@ -3,6 +3,8 @@ package seedu.address.model.module;
 import java.util.List;
 import java.util.function.Predicate;
 
+import seedu.address.commons.util.StringUtil;
+
 /**
  * Tests that a {@code Module} contains a {@code Tag} matching any of the tag names given.
  */
@@ -23,6 +25,6 @@ public class ModuleContainsTagsPredicate implements Predicate<Module> {
     public boolean test(Module module) {
         return tagNames.stream().anyMatch(name ->
               module.getTags().stream().anyMatch(tag ->
-                     tag.tagName.equalsIgnoreCase(name)));
+                     StringUtil.containsCharSequenceIgnoreCase(tag.tagName, name)));
     }
 }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String VALIDATION_REGEX = "(\\p{Alnum}+\\p{Blank}?)+";
 
     public final String tagName;
     private int moduleCount;

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_MODULES_FOUND_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_CORE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_NON_CORE;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalModules.CS2103T;
 import static seedu.address.testutil.TypicalModules.CS3216;
@@ -78,21 +79,21 @@ public class FindCommandTest {
     @Test
     public void execute_oneTagKeyword_oneModuleFound() {
         String expectedMessage = String.format(MESSAGE_MODULES_FOUND_OVERVIEW, 1);
-        CompoundFindPredicate predicate = preparePredicate(VALID_TAG_CORE);
+        CompoundFindPredicate predicate = preparePredicate(VALID_TAG_NON_CORE);
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredModuleList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.singletonList(CS2103T), model.getFilteredModuleList());
+        assertEquals(Collections.singletonList(CS3216), model.getFilteredModuleList());
     }
 
     @Test
     public void execute_oneCapitalizedTagKeyword_oneModuleFound() {
         String expectedMessage = String.format(MESSAGE_MODULES_FOUND_OVERVIEW, 1);
-        CompoundFindPredicate predicate = preparePredicate(VALID_TAG_CORE.toUpperCase());
+        CompoundFindPredicate predicate = preparePredicate(VALID_TAG_NON_CORE.toUpperCase());
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredModuleList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.singletonList(CS2103T), model.getFilteredModuleList());
+        assertEquals(Collections.singletonList(CS3216), model.getFilteredModuleList());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -22,18 +22,32 @@ public class TagTest {
     }
 
     @Test
-    public void isValidTagName_null_throwsNullPointerException() {
-        // null tag name
-        assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
-    }
-
-    @Test
     public void constructor_validTagName_tagWithDefaultModuleCount() {
         String expectedTagName = "core";
         int expectedModuleCount = 1;
         Tag actualTag = new Tag(expectedTagName);
         assertEquals(expectedTagName, actualTag.tagName);
         assertEquals(expectedModuleCount, actualTag.getModuleCount());
+    }
+
+    @Test
+    public void isValidTagName() {
+        // null name --> throw NPE
+        assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+        // single word with letters
+        assertTrue(Tag.isValidTagName("core"));
+        // multiword with letters
+        assertTrue(Tag.isValidTagName("core module"));
+        // single word with number
+        assertTrue(Tag.isValidTagName("core1"));
+        // uppercase letter
+        assertTrue(Tag.isValidTagName("Core"));
+        // empty name
+        assertFalse(Tag.isValidTagName(""));
+        // only whitespace
+        assertFalse(Tag.isValidTagName("  "));
+        // multiword with extra space in between
+        assertFalse(Tag.isValidTagName("core   module"));
     }
 
     @Test


### PR DESCRIPTION
Closes #166 

### Changes
* Change regex for tagName. It now matches >= 1 alphanumeric character, before matching a whitespace character if present, before recursing.
* To support multiword tags, `find` is changed such that each keyword only needs to match part of a tag. Otherwise, searching for "core module" will attempt to find a tag named "core" and another tag named "module". It won't match a single multiword tag named "core module".  Now, it will match all tags containing "core" or "module" or both.
* Update tests accordingly
* Update UG accordingly
