### PR TITLE
Add check for equal fields in edit command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -80,6 +80,8 @@ public class Messages {
     public static final String MESSAGE_EDIT_SUCCESS = "The following module has been successfully edited:"
         + "\n\n%1$s\n\nEdited module:\n\n%2$s";
     public static final String MESSAGE_NOT_EDITED = "You must provide at least one field to edit!";
+    public static final String MESSAGE_ALL_EDIT_FIELDS_SAME = "The new fields provided have the same values as the "
+                                                                      + "current ones.";
 
     // exit command
     public static final String EXIT_COMMAND_WORD = "exit";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_ALL_EDIT_FIELDS_SAME;
 import static seedu.address.commons.core.Messages.MESSAGE_DUPLICATE_MODULE;
 import static seedu.address.commons.core.Messages.MESSAGE_EDIT_SUCCESS;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_MODULE;
@@ -53,6 +54,11 @@ public class EditCommand extends Command {
         }
 
         Module editedModule = createEditedModule(moduleToEdit.get(), editModuleDescriptor);
+
+        if (moduleToEdit.get().equals(editedModule)) {
+            throw new CommandException(MESSAGE_ALL_EDIT_FIELDS_SAME);
+        }
+
         if (!moduleToEdit.get().isSameModule(editedModule) && model.hasModule(editedModule)) {
             throw new CommandException(String.format(MESSAGE_DUPLICATE_MODULE, editedModule.getModuleCode()));
         }


### PR DESCRIPTION
Closes #152 

### Changes
* When executing `EditCommand`, check if the edited module is the same as the original one. If it is, display an error message instead of continuing to "edit" it
* Add test for this + tweak one existing test that's affected by this new change
* Minor: I noticed that there was a lot of repeated code in `EditCommandTest` to retrieve modules from the test model, so I've abstracted it out to 2 fxns